### PR TITLE
adds basic support for applying updated

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -75,6 +75,12 @@ func (c *ApplyCommand) Run(ctx context.Context) error {
 	if pccManagedString != "true" {
 		return fmt.Errorf("client %s is not managed by pcc", client.ClientId)
 	}
+	clientFromConfig := clientFromClientConfig(clientIn)
+	clientFromConfig.ClientAuth = client.ClientAuth
+	_, r, err = adminClient.OauthClientsAPI.UpdateOauthClient(ctx, client.ClientId).Body(*clientFromConfig).Execute()
+	if err != nil {
+		return fmt.Errorf("error updating client %s: %v", client.ClientId, err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
When a client configuration already exists the tool must first check if it is allowed to manage the config and then it must preserve the client auth settings during the update process.